### PR TITLE
[DI-932] Use fix name when no title

### DIFF
--- a/src/main/java/org/getyourguide/parquet/json/JsonSchemaConverter.java
+++ b/src/main/java/org/getyourguide/parquet/json/JsonSchemaConverter.java
@@ -54,8 +54,15 @@ public class JsonSchemaConverter {
 
     public MessageType convert(ObjectSchema jsonClass) {
         LOG.debug("Converting OpenAPI described JsonNode class \"" + jsonClass.getClass() + "\" to parquet schema.");
+
+        String title = jsonClass.getTitle();
+
+        if (title == null) {
+            title = "ParquetSchema";
+        }
+
         MessageType messageType = convertFields(Types.buildMessage(), jsonClass.getProperties())
-                .named(jsonClass.getTitle());
+                .named(title);
         return messageType;
     }
 
@@ -141,7 +148,14 @@ public class JsonSchemaConverter {
             // so we assume that a "schema" with no type is an object
             Schema field = descriptor;
             descriptor = new ObjectSchema();
-            descriptor.setType(field.getTitle());
+
+            String fieldTitle = field.getTitle();
+
+            if (fieldTitle == null) {
+                fieldTitle = "ParquetSchema";
+            }
+
+            descriptor.setTitle(fieldTitle);
             descriptor.setProperties(field.getProperties());
             descriptor.setAdditionalProperties(field.getAdditionalProperties());
             descriptor.setName(field.getName());


### PR DESCRIPTION
We use the property "title" from the OpenAPI specification as a schema name for Parquet (meta-data). When this property is not set (optional from the spec), we had an exception with Name required. Now when this property is not set, we use the default `ParquetSchema`.