### PR TITLE
Di 934

### DIFF
--- a/src/main/java/org/getyourguide/parquet/json/JsonWriteSupport.java
+++ b/src/main/java/org/getyourguide/parquet/json/JsonWriteSupport.java
@@ -129,7 +129,7 @@ public class JsonWriteSupport<T extends JsonNode> extends WriteSupport<T> {
 
         void writeField(Object value) {
 
-            if (value instanceof NullNode) {
+            if (value instanceof NullNode || value == null) {
                 LOG.debug("Null value");
                 return;
             }
@@ -340,12 +340,24 @@ public class JsonWriteSupport<T extends JsonNode> extends WriteSupport<T> {
                             }
 
                         } else {
+
+                            if (valueSchema.getNullable() == null || !valueSchema.getNullable()) {
+                                throw new RequiredFieldException(String.format("Field %s missing/null and"
+                                    + " writeDefaultValue enabled", lkpFieldName));
+                            } else {
+                                fieldIndex++;
+                                continue;
+                            }
+                        }
+                    } else {
+                        if (valueSchema.getNullable() == null || !valueSchema.getNullable()) {
+                            throw new RequiredFieldException(String.format("Field %s missing/null"
+                                    + " but defined as non-nullable",
+                                lkpFieldName));
+                        } else {
                             fieldIndex++;
                             continue;
                         }
-                    } else {
-                        fieldIndex++;
-                        continue;
                     }
                 }
 
@@ -503,7 +515,7 @@ public class JsonWriteSupport<T extends JsonNode> extends WriteSupport<T> {
         @Override
         final void writeField(Object value) {
 
-            if (value instanceof NullNode) {return;}
+            if (value instanceof NullNode || value == null) {return;}
 
             ArrayNode node = (ArrayNode) value;
 

--- a/src/main/java/org/getyourguide/parquet/json/RequiredFieldException.java
+++ b/src/main/java/org/getyourguide/parquet/json/RequiredFieldException.java
@@ -1,0 +1,22 @@
+package org.getyourguide.parquet.json;
+
+
+import org.apache.parquet.ParquetRuntimeException;
+
+public class RequiredFieldException extends ParquetRuntimeException {
+  RequiredFieldException() {
+    super();
+  }
+
+  RequiredFieldException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  RequiredFieldException(String message) {
+    super(message);
+  }
+
+  RequiredFieldException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/src/test/java/org/getyourguide/parquet/json/JsonParquetWriterTest.java
+++ b/src/test/java/org/getyourguide/parquet/json/JsonParquetWriterTest.java
@@ -9,13 +9,18 @@ import java.io.File;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 public class JsonParquetWriterTest extends JsonParquetTest{
 
     @ClassRule
     public static TemporaryFolder folder = new TemporaryFolder();
+
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
 
     private String getFullPath(String filename) {
         return folder.getRoot()+"/"+filename;
@@ -68,5 +73,12 @@ public class JsonParquetWriterTest extends JsonParquetTest{
     public void testWriteMapOfObjects() throws Exception {
         testFile("TestMapStructureofObject");
     }
+
+    @Test
+    public void testMissingInPayload() throws Exception {
+        exceptionRule.expect(RequiredFieldException.class);
+        testFile("NullInPayload");
+    }
+
 
 }

--- a/src/test/resources/openapi.yaml
+++ b/src/test/resources/openapi.yaml
@@ -226,3 +226,13 @@ components:
       example:
         nested:
           key1: "Hello World!"
+    NullInPayload:
+      title: "NullInPayload"
+      type: object
+      properties:
+        key1:
+          type: string
+        key2:
+          type: string
+      example:
+        key2: "hello"


### PR DESCRIPTION
When a required (non-nullable) field is defined but missing from the payload/or null, the produced Parquet file is corrupted (because the field is actually expected but garbage is written).

This PR adds an exception to be thrown when the field is missing or `NULL`