### PR TITLE
Revert "NoTicket: Use self-hosted runners instead of GitHub-hosted runners"

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: [self-hosted, small]
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Reverts getyourguide/parquet-json#9 as this is a public repo, and we didn't configure our self-hosted runners on public repos for security reasons.