### PR TITLE
Upgrade to Java 17 and bump all dependencies

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
-    - name: Set up JDK 1.8
+    - name: Set up JDK 17
       uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
       with:
         distribution: temurin

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,1 +1,1 @@
-java=1.8.0-tem
+java=17.0.13-tem

--- a/pom.xml
+++ b/pom.xml
@@ -23,22 +23,22 @@
   <groupId>org.getyourguide.parquet</groupId>
   <artifactId>parquet-json</artifactId>
   <packaging>jar</packaging>
-  <version>1.12.0</version>
+  <version>1.17.1</version>
 
   <properties>
-    <elephant-bird.version>4.4</elephant-bird.version>
-    <protobuf.version>3.5.1</protobuf.version>
-    <truth-proto-extension.version>1.0</truth-proto-extension.version>
+    <elephant-bird.version>4.17</elephant-bird.version>
+    <protobuf.version>3.25.5</protobuf.version>
+    <truth-proto-extension.version>1.4.5</truth-proto-extension.version>
 
     <jackson.groupId>com.fasterxml.jackson.core</jackson.groupId>
     <jackson.package>com.fasterxml.jackson</jackson.package>
-    <jackson.version>2.9.10</jackson.version>
-    <slf4j.version>1.7.22</slf4j.version>
-    <hadoop.version>2.7.3</hadoop.version>
-    <parquet.format.version>2.8.0</parquet.format.version>
-    <format.thrift.version>0.14.0</format.thrift.version>
-    <mockito.version>1.10.19</mockito.version>
-    <maven-jar-plugin.version>2.4</maven-jar-plugin.version>
+    <jackson.version>2.18.2</jackson.version>
+    <slf4j.version>2.0.16</slf4j.version>
+    <hadoop.version>3.3.6</hadoop.version>
+    <parquet.format.version>2.10.0</parquet.format.version>
+    <format.thrift.version>0.21.0</format.thrift.version>
+    <mockito.version>5.14.2</mockito.version>
+    <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
 
   </properties>
 
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>io.swagger.parser.v3</groupId>
       <artifactId>swagger-parser</artifactId>
-      <version>2.0.19</version>
+      <version>2.1.22</version>
     </dependency>
     <dependency>
       <groupId>com.google.truth.extensions</groupId>
@@ -151,7 +151,7 @@
         </executions>
       </plugin>
       <plugin>
-        <version>3.2.1</version>
+        <version>3.6.0</version>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <executions>
@@ -166,7 +166,7 @@
       <plugin>
         <groupId>com.github.os72</groupId>
         <artifactId>protoc-jar-maven-plugin</artifactId>
-        <version>3.8.0</version>
+        <version>3.11.4</version>
         <executions>
           <execution>
             <id>generate-sources</id>
@@ -187,12 +187,12 @@
         </executions>
       </plugin>
       <plugin>
-        <version>3.8.1</version>
+        <version>3.13.0</version>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>8</source>
-          <target>8</target>
+          <source>17</source>
+          <target>17</target>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
## Summary
- Upgrade Java target from 8 to 17 (matching the main consumer of this library)
- Bump all dependencies to current stable versions — notably Jackson 2.9.10 → 2.18.2 (EOL, multiple CVEs), Hadoop 2.7.3 → 3.3.6, Mockito 1.x → 5.x, SLF4J 1.7 → 2.0, Swagger Parser 2.0 → 2.1
- Upgrade all Maven plugins (compiler, jar, shade, protoc-jar)

## Test plan
- [x] `mvn test` passes locally (25 tests, 0 failures)
- [x] CI build passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)