### PR TITLE
Add release pipeline to CodeArtifact

### DIFF
--- a/.github/maven-settings.xml
+++ b/.github/maven-settings.xml
@@ -1,0 +1,11 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+    <server>
+      <id>getyourguide-private-store</id>
+      <username>aws</username>
+      <password>${env.CODEARTIFACT_PUBLISH_TOKEN}</password>
+    </server>
+  </servers>
+</settings>

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,28 +1,44 @@
-# This workflow will build a Java project with Maven
-# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
-
-name: Java CI with Maven
+name: Java CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 permissions:
-  contents: write
+  contents: read
+  id-token: write
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
-
+    runs-on: [self-hosted, java-small]
     steps:
-    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
-    - name: Set up JDK 17
-      uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
-      with:
-        distribution: temurin
-        java-version-file: .sdkmanrc
-    - name: Test
-      run: mvn test -B
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - name: Set up JDK
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
+        with:
+          distribution: temurin
+          java-version-file: .sdkmanrc
+      - name: Test
+        run: mvn test -B
+
+  publish-snapshot:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    needs: build
+    runs-on: [self-hosted, java-small]
+    steps:
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - name: Set up JDK
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
+        with:
+          distribution: temurin
+          java-version-file: .sdkmanrc
+      - name: Fetch CodeArtifact publish token
+        uses: getyourguide/actions/fetch-codeartifact-publish-token@main
+        with:
+          ci-role-name: ci-datastores-config
+      - name: Set snapshot version
+        run: mvn versions:set -DnewVersion=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)-SNAPSHOT -B
+      - name: Publish snapshot
+        run: mvn deploy -B -DskipTests -s .github/maven-settings.xml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: [self-hosted, java-small]
+    steps:
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - name: Set up JDK
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
+        with:
+          distribution: temurin
+          java-version-file: .sdkmanrc
+      - name: Fetch CodeArtifact publish token
+        uses: getyourguide/actions/fetch-codeartifact-publish-token@main
+        with:
+          ci-role-name: ci-datastores-config
+      - name: Set release version from tag
+        run: mvn versions:set -DnewVersion=${GITHUB_REF_NAME#v} -B
+      - name: Publish release
+        run: mvn deploy -B -DskipTests -s .github/maven-settings.xml

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,19 @@
     </dependencies>
   </dependencyManagement>
 
+  <distributionManagement>
+    <repository>
+      <id>getyourguide-private-store</id>
+      <name>getyourguide-private-store</name>
+      <url>https://getyourguide-130607246975.d.codeartifact.eu-central-1.amazonaws.com/maven/private-store/</url>
+    </repository>
+    <snapshotRepository>
+      <id>getyourguide-private-store</id>
+      <name>getyourguide-private-store</name>
+      <url>https://getyourguide-130607246975.d.codeartifact.eu-central-1.amazonaws.com/maven/private-store/</url>
+    </snapshotRepository>
+  </distributionManagement>
+
   <developers>
     <developer>
       <id>emmanuelbrard</id>

--- a/service-provisioning.yml
+++ b/service-provisioning.yml
@@ -1,0 +1,6 @@
+service:
+  name: datastores-config
+  owner: di
+  type: Other
+ci:
+  has_custom_iam_policy: true

--- a/service-provisioning.yml
+++ b/service-provisioning.yml
@@ -1,5 +1,5 @@
 service:
-  name: datastores-config
+  name: parquet-json
   owner: di
   type: Other
 ci:


### PR DESCRIPTION
## Summary
- Publishes a SNAPSHOT version (`<version>-SNAPSHOT`) to CodeArtifact on every master merge
- Publishes a proper release to CodeArtifact when a GitHub Release is created (version from tag)
- Adds `distributionManagement` to pom.xml targeting `private-store`
- Adds `service-provisioning.yml` for CI IAM role provisioning
- Runs on self-hosted `java-small` runners

## Prerequisites
- The `ci-datastores-config` role needs CodeArtifact publish permissions in [getyourguide/service-iam-config](https://github.com/getyourguide/service-iam-config) (if not already configured)

## Test plan
- [ ] Verify CI passes on this PR (build job)
- [ ] After merge, confirm snapshot is published to CodeArtifact
- [ ] Create a test GitHub Release and confirm the artifact appears in CodeArtifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)